### PR TITLE
Update template.yml

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -33,5 +33,5 @@ Resources:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt BedrockAgentTest.Arn
       Principal: bedrock.amazonaws.com
-      SourceAccount: ${AWS::AccountId}
+      SourceAccount: !Sub ${AWS::AccountId}
       SourceArn: !Ref AgentARN


### PR DESCRIPTION
Missing intrinsic function on line 36. If !Sub is missing then an error occurs

```
CREATE_FAILED                    AWS::Lambda::Permission          BedrockAgentTestPermission       Properties validation failed   
                                                                                                   for resource                   
                                                                                                   BedrockAgentTestPermission     
                                                                                                   with message: [#/SourceArn:    
                                                                                                   string [arn:aws:bedrock:us-    
                                                                                                   east-1:123456789012] does not  
                                                                                                   match pattern ^arn:(aws[a-zA-  
                                                                                                   Z0-9-]*):([a-zA-Z0-9\-])+:([a- 
                                                                                                   z]{2}((-gov)|(-iso([a-z]?)))?- 
                                                                                                   [a-z]+-                        
                                                                                                   \d{1})?:(\d{12})?:(.*)$,       
                                                                                                   #/SourceAccount: expected      
                                                                                                   maxLength: 12, actual: 17,     
                                                                                                   #/SourceAccount: string        
                                                                                                   [${AWS::AccountId}] does not   
                                                                                                   match pattern ^\d{12}$]
```